### PR TITLE
feat(privacy): add global toggle and short-circuit getLocationPermiss…

### DIFF
--- a/cidaas/src/main/java/de/cidaas/sdk/android/library/common/Privacy.java
+++ b/cidaas/src/main/java/de/cidaas/sdk/android/library/common/Privacy.java
@@ -1,0 +1,17 @@
+package de.cidaas.sdk.android.library.common;
+
+public final class Privacy {
+    private static volatile boolean locationEnabled = true;
+
+    private Privacy() {}
+
+    /** Enable/disable any SDK path that depends on location permission. */
+    public static void setLocationEnabled(boolean enabled) {
+        locationEnabled = enabled;
+    }
+
+    /** Current location toggle state (true = enabled / legacy behavior). */
+    public static boolean isLocationEnabled() {
+        return locationEnabled;
+    }
+}

--- a/cidaas/src/main/java/de/cidaas/sdk/android/library/locationlibrary/LocationDetails.java
+++ b/cidaas/src/main/java/de/cidaas/sdk/android/library/locationlibrary/LocationDetails.java
@@ -23,6 +23,8 @@ import timber.log.Timber;
 
 import static android.content.Context.LOCATION_SERVICE;
 
+import de.cidaas.sdk.android.library.common.Privacy;
+
 public class LocationDetails implements LocationListener {
 
     private final Context mContext;
@@ -96,6 +98,11 @@ public class LocationDetails implements LocationListener {
 
     @RequiresApi(api = Build.VERSION_CODES.M)
     private void getLocationPermissions() {
+
+	if (!Privacy.isLocationEnabled()) {
+   		 return false;
+	}
+
         if (ContextCompat.checkSelfPermission(mContext, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(mContext, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
             getLocationAfterPermission();

--- a/cidaas/src/main/java/de/cidaas/sdk/android/service/helperforservice/Headers/Headers.java
+++ b/cidaas/src/main/java/de/cidaas/sdk/android/service/helperforservice/Headers/Headers.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import de.cidaas.sdk.android.entities.DeviceInfoEntity;
 import de.cidaas.sdk.android.helper.general.DBHelper;
 import de.cidaas.sdk.android.library.locationlibrary.LocationDetails;
+import de.cidaas.sdk.android.library.common.Privacy;
 import timber.log.Timber;
 
 public class Headers {
@@ -55,8 +56,11 @@ public class Headers {
                 headers.put("Content-Type", contentType);
             }
 
-            headers.put("lat", LocationDetails.getShared(context).getLatitude());
-            headers.put("lon", LocationDetails.getShared(context).getLongitude());
+            if (Privacy.isLocationEnabled()) {
+   		 
+                headers.put("lat", LocationDetails.getShared(context).getLatitude());
+                headers.put("lon", LocationDetails.getShared(context).getLongitude());
+        	}
 
             DeviceInfoEntity deviceInfoEntity = DBHelper.getShared().getDeviceInfo();
 


### PR DESCRIPTION
###  Add global privacy toggle for location

**Motivation**

Currently, LocationDetails checks Android location permissions directly.
This means the SDK may use device location whenever the app has ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION, even if the host app only requested those permissions for other purposes (e.g. maps).

This PR introduces a global privacy switch that allows apps to disable location usage inside the SDK without breaking existing behavior.

- Backward compatible – by default, location remains enabled.

- Minimal change – only one new helper (Privacy) and a guard in getLocationPermissions().

-  Explicit opt-out – apps can now enforce “SDK must not use location” regardless of OS-level permissions.

**Changes**

Added de.cidaas.sdk.android.library.common.Privacy class:

Privacy.setLocationEnabled(boolean)

Privacy.isLocationEnabled()

Updated LocationDetails#getLocationPermissions(Context):

Returns false immediately if Privacy.isLocationEnabled() is false.

Updated README with usage instructions.

**Usage**

Default (no change)

// Legacy behavior preserved

boolean hasPermission = new LocationDetails().getLocationPermissions(context);
// returns true if OS location permissions are granted

Disable SDK location usage completely

**Java**

import de.cidaas.sdk.android.library.common.Privacy;

// e.g., at app startup, after reading user settings, or remote config:
Privacy.setLocationEnabled(false);

// now, even if the app has ACCESS_FINE_LOCATION, the SDK acts as if it does not
boolean hasPermission = new LocationDetails().getLocationPermissions(context);
// will always return false


**Kotlin**

import de.cidaas.sdk.android.library.common.Privacy

// disable at app startup
Privacy.setLocationEnabled(false)

// SDK now behaves as if location permission is never granted
val hasPermission = LocationDetails().getLocationPermissions(context)
// always returns false

Optional: configure via SDK init (if exposed)
Cidaas sdk = new Cidaas(context)
    .setLocationEnabled(false); // ensures SDK ignores location permissions

**Example scenario**

Your app uses location for maps/navigation → permission is granted.

For authentication, you do not want the SDK to read location.

With this PR, call Privacy.setLocationEnabled(false) and the SDK behaves as if no location permission is present.

**Migration**

**No code changes required for existing apps.**

To disable SDK location usage, call Privacy.setLocationEnabled(false) early in app startup.

**Next steps**

In a future major release, consider flipping the default to disabled (false) for stricter privacy by default.